### PR TITLE
Added streamable-http transport and functional healthcheck

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "sympy-mcp": {
+      "type": "http",
+      "url": "http://localhost:8082/mcp"
+    }
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,5 @@ EXPOSE 8081
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:8081/healthcheck || exit 1
 
-# Run the server with SSE transport
-CMD ["uv", "run", "--with", "mcp[cli]", "--with", "sympy", "mcp", "run", "/app/server.py", "--transport", "sse"] 
+# Run the server with streamable-http transport
+CMD ["uv", "run", "python", "/app/server.py", "--transport", "streamable-http", "--mcp-host", "0.0.0.0", "--mcp-port", "8081"]

--- a/README.md
+++ b/README.md
@@ -229,6 +229,24 @@ To set up with [5ire](https://github.com/nanbingxyz/5ire), open 5ire and go to T
 
 Replace `/ABSOLUTE_PATH_TO/server.py` with the actual path to your sympy-mcp server.py file.
 
+## HTTP Transport (Streamable HTTP / SSE)
+
+The server supports MCP over HTTP using the [streamable-http transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) introduced in MCP spec 2025-03-26. This replaces the legacy SSE transport and exposes a single `/mcp` endpoint that clients connect to over HTTP.
+
+This is the recommended transport when running the server as a standalone process or in a container, because it allows any HTTP-capable MCP client to connect without needing to launch the server as a subprocess.
+
+```bash
+# Run locally with HTTP transport
+uv run python server.py --transport streamable-http
+
+# Override host/port
+uv run python server.py --transport streamable-http --mcp-host 127.0.0.1 --mcp-port 9000
+```
+
+The legacy `--transport sse` flag is still supported for backward compatibility.
+
+A `/healthcheck` endpoint is also exposed that runs a full MCP protocol round-trip (initialize → tools/list → session teardown) and returns `{"status": "ok", "tool_count": N}`.
+
 ## Running in Container
 
 You can build and run the server using Docker locally:
@@ -239,6 +257,13 @@ docker build -t sympy-mcp .
 
 # Run the Docker container
 docker run -p 8081:8081 sympy-mcp
+```
+
+Or use Docker Compose from the `docker/` directory:
+
+```bash
+cd docker
+docker compose up -d --build
 ```
 
 Alternatively, you can pull the pre-built image from GitHub Container Registry:

--- a/README.md
+++ b/README.md
@@ -443,6 +443,32 @@ $$
 -12
 $$
 
+## Example Interaction 3: Coupled ODE System (Fluid Dynamics)
+
+This example demonstrates solving a coupled system of ODEs and verifying the solution against an algebraic steady-state analysis — a task where LLMs typically hallucinate without a CAS to ground each step.
+
+**User**:
+
+> Use the sympy-mcp tools to solve this symbolically — do not compute by hand.
+>
+> Two cylindrical tanks are connected by a pipe. Tank 1 has cross-sectional area A₁ = 2 m² and receives a constant inflow of Q = 0.5 m³/s. Water drains from Tank 1 into Tank 2 through a pipe with flow rate proportional to the height difference: q₁₂ = k·(h₁ - h₂) where k = 0.3 m²/s. Tank 2 has cross-sectional area A₂ = 1 m² and drains to the outside at rate q₂ = k·h₂ with the same k.
+>
+> Set up and solve the coupled system of ODEs for the water heights h₁(t) and h₂(t), starting from empty tanks (h₁(0) = 0, h₂(0) = 0). Then find the steady-state heights as t → ∞ by solving the equilibrium equations algebraically, and verify they match the long-term solution of the ODEs.
+
+**Assistant**: (Internal tool chain)
+
+1. `intro_many` — introduce `t`, `k`, `A1`, `A2`, `Q` with real/positive assumptions
+2. `introduce_function` × 2 — introduce `h1(t)` and `h2(t)` as unknown functions
+3. `introduce_expression` × 2 — encode the mass-balance ODEs:
+
+$$A_1 \frac{dh_1}{dt} = Q - k(h_1 - h_2), \quad A_2 \frac{dh_2}{dt} = k(h_1 - h_2) - k h_2$$
+
+4. `substitute_expression` — substitute numeric values for `k`, `A1`, `A2`, `Q`
+5. `dsolve_ode` × 2 — solve the coupled system; apply initial conditions via `substitute_expression`
+6. `introduce_expression` × 2 — encode equilibrium equations (derivatives set to zero)
+7. `solve_linear_system` — solve the 2×2 algebraic system for `h1*`, `h2*`
+8. `print_latex_expression` — display both the time-domain solution and the steady-state values
+
 ## Security Disclaimer
 
 This server runs on your computer and gives the language model access to run Python logic. Notably it uses Sympy's `parse_expr` to parse mathematical expressions, which is uses `eval` under the hood, effectively allowing arbitrary code execution. By running the server, you are trusting the code that Claude generates. Running in the Docker image is slightly safer, but it's still a good idea to review the code before running it.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  sympy-mcp:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    ports:
+      - "8082:8081"
+    restart: unless-stopped

--- a/server.py
+++ b/server.py
@@ -87,6 +87,8 @@ mcp = FastMCP(
     "sympy-mcp",
     dependencies=["sympy", "pydantic", "einsteinpy"],
     instructions="Provides access to the Sympy computer algebra system, which can perform symbolic manipulation of mathematical expressions.",
+    host="0.0.0.0",
+    port=8081,
 )
 
 @mcp.custom_route("/healthcheck", methods=["GET"])

--- a/server.py
+++ b/server.py
@@ -1,7 +1,11 @@
-# A stateful MCP server that holds a sympy sesssion, with symbol table of variables
+# A stateful MCP server that holds a sympy session, with symbol table of variables
 # that can be used in the tools API to define and manipulate expressions.
 
 from mcp.server.fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+import httpx
+import json
 import sympy
 import argparse
 import logging
@@ -84,6 +88,53 @@ mcp = FastMCP(
     dependencies=["sympy", "pydantic", "einsteinpy"],
     instructions="Provides access to the Sympy computer algebra system, which can perform symbolic manipulation of mathematical expressions.",
 )
+
+@mcp.custom_route("/healthcheck", methods=["GET"])
+async def healthcheck(request: Request) -> Response:
+    try:
+        port = mcp.settings.port
+        url = f"http://127.0.0.1:{port}/mcp"
+        headers = {"Accept": "application/json, text/event-stream"}
+
+        async with httpx.AsyncClient() as client:
+            init = await client.post(url, json={
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "healthcheck", "version": "1.0"},
+                },
+            }, headers=headers)
+            session_id = init.headers.get("mcp-session-id")
+
+            req_headers = {**headers}
+            if session_id:
+                req_headers["mcp-session-id"] = session_id
+
+            resp = await client.post(url, json={
+                "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {},
+            }, headers=req_headers)
+
+            # streamable-http may return SSE (text/event-stream) or plain JSON
+            content_type = resp.headers.get("content-type", "")
+            if "text/event-stream" in content_type:
+                data = None
+                for line in resp.text.splitlines():
+                    if line.startswith("data: "):
+                        data = json.loads(line[6:])
+                        break
+                tools = (data or {}).get("result", {}).get("tools", [])
+            else:
+                tools = resp.json().get("result", {}).get("tools", [])
+
+            # Close the session to avoid accumulating orphaned sessions
+            if session_id:
+                await client.delete(url, headers={"mcp-session-id": session_id})
+
+            return JSONResponse({"status": "ok", "tool_count": len(tools)})
+    except Exception as e:
+        return JSONResponse({"status": "error", "detail": str(e)}, status_code=500)
+
 
 # Global store for sympy variables and expressions
 local_vars: Dict[str, sympy.Symbol] = {}
@@ -1839,19 +1890,20 @@ def main():
     parser.add_argument(
         "--mcp-host",
         type=str,
-        default="127.0.0.1",
-        help="Host to run MCP server on (only used for sse), default: 127.0.0.1",
+        default="0.0.0.0",
+        help="Host to bind for HTTP transports (default: 0.0.0.0)",
     )
     parser.add_argument(
         "--mcp-port",
         type=int,
-        help="Port to run MCP server on (only used for sse), default: 8081",
+        default=8081,
+        help="Port to bind for HTTP transports (default: 8081)",
     )
     parser.add_argument(
         "--transport",
         type=str,
         default="stdio",
-        choices=["stdio", "sse"],
+        choices=["stdio", "sse", "streamable-http"],
         help="Transport protocol for MCP, default: stdio",
     )
     args = parser.parse_args()
@@ -1859,31 +1911,24 @@ def main():
     # Call to initialize units
     initialize_units()
 
-    if args.transport == "sse":
+    if args.transport in ("sse", "streamable-http"):
         try:
-            # Set up logging
-            log_level = logging.INFO
-            logging.basicConfig(level=log_level)
-            logging.getLogger().setLevel(log_level)
+            logging.basicConfig(level=logging.INFO)
+            logging.getLogger("httpx").setLevel(logging.WARNING)
 
-            # Configure MCP settings
             mcp.settings.log_level = "INFO"
-            if args.mcp_host:
-                mcp.settings.host = args.mcp_host
-            else:
-                mcp.settings.host = "127.0.0.1"
+            mcp.settings.host = args.mcp_host
+            mcp.settings.port = args.mcp_port
 
-            if args.mcp_port:
-                mcp.settings.port = args.mcp_port
+            if args.transport == "sse":
+                endpoint = f"http://{mcp.settings.host}:{mcp.settings.port}/sse"
             else:
-                mcp.settings.port = 8081
+                endpoint = f"http://{mcp.settings.host}:{mcp.settings.port}/mcp"
 
-            logger.info(
-                f"Starting MCP server on http://{mcp.settings.host}:{mcp.settings.port}/sse"
-            )
+            logger.info(f"Starting MCP server on {endpoint}")
             logger.info(f"Using transport: {args.transport}")
 
-            mcp.run(transport="sse")
+            mcp.run(transport=args.transport)
         except KeyboardInterrupt:
             logger.info("Server stopped by user")
     else:


### PR DESCRIPTION
- Switch server to MCP streamable-http transport (replaces legacy SSE)
- Run server directly via python instead of mcp CLI to honour host/port args
- Bind to 0.0.0.0 by default for container environments
- Add /healthcheck endpoint that runs full MCP initialize + tools/list + session teardown
- Add docker/docker-compose.yml and .vscode/mcp.json for local dev